### PR TITLE
Unset exe variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,7 @@ jobs:
 
           for dir in bins-* ; do
               platform=${dir#"bins-"}
+              unset exe
               if [[ $platform =~ "windows" ]]; then
                   exe=".exe"
               fi


### PR DESCRIPTION
If a Windows build happens to run before a Linux one, the ".exe" suffix carries over to the Linux build as well and causes issues; this commit fixes the issue.